### PR TITLE
add pyproject.toml for install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = [
+    "setuptools>=65",
+    "wheel",
+    "cython",
+    "numpy",
+    "tqdm",
+    "autograd",
+    "numba",
+    "scikit-learn"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ssm"
+version = "0.0.1"
+description = "Bayesian learning and inference for a variety of state space models"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.7"
+
+authors = [
+    { name = "Scott Linderman", email = "scott.linderman@stanford.edu" }
+]
+
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: C",
+    "Topic :: Software Development",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+]
+
+[tool.setuptools]
+zip-safe = false
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/setup.py
+++ b/setup.py
@@ -1,65 +1,29 @@
-#! /usr/bin/env python
-import os
-import numpy as np
-from Cython.Build import cythonize
+from setuptools import setup
 from setuptools.extension import Extension
-from setuptools import setup, find_packages
+from Cython.Build import cythonize
+import numpy as np
+import os
 
-# Make sources available using relative paths from this file's directory.
-os.chdir(os.path.dirname(os.path.abspath(__file__)))
-
-# Create the extensions. Manually enumerate the required
-# Only compile with OpenMP if user asks for it
-USE_OPENMP = os.environ.get('USE_OPENMP', False)
+USE_OPENMP = os.environ.get("USE_OPENMP", False)
 print("USE_OPENMP", USE_OPENMP)
-extensions = []
-extensions.append(
-    Extension('ssm.cstats',
-              extra_compile_args=["-fopenmp"] if USE_OPENMP else [],
-              extra_link_args=["-fopenmp"] if USE_OPENMP else [],
-              language="c++",
-              sources=["ssm/cstats.pyx"],
-              include_dirs=[np.get_include()]
-              )
+
+extra_compile_args = ["-fopenmp"] if USE_OPENMP else []
+extra_link_args = ["-fopenmp"] if USE_OPENMP else []
+
+extensions = [
+    Extension(
+        "ssm.cstats",
+        sources=["ssm/cstats.pyx"],
+        language="c++",
+        include_dirs=[np.get_include()],
+        extra_compile_args=extra_compile_args,
+        extra_link_args=extra_link_args,
+    )
+]
+
+setup(
+    ext_modules=cythonize(
+        extensions,
+        compiler_directives={"language_level": "3"},
+    )
 )
-
-DISTNAME = 'ssm'
-DESCRIPTION = 'Bayesian learning and inference for a variety of state space models'
-with open('README.md') as fp:
-    LONG_DESCRIPTION = fp.read()
-MAINTAINER = 'Scott Linderman'
-MAINTAINER_EMAIL = 'scott.linderman@stanford.edu'
-URL = ''
-LICENSE = 'MIT'
-DOWNLOAD_URL = ''
-VERSION = '0.0.1'
-
-
-if __name__ == "__main__":
-    setup(name=DISTNAME,
-          maintainer=MAINTAINER,
-          maintainer_email=MAINTAINER_EMAIL,
-          description=DESCRIPTION,
-          license=LICENSE,
-          url=URL,
-          version=VERSION,
-          download_url=DOWNLOAD_URL,
-          long_description=LONG_DESCRIPTION,
-          zip_safe=False,  # the package can run out of an .egg file
-          classifiers=[
-              'Intended Audience :: Science/Research',
-              'Intended Audience :: Developers',
-              'License :: OSI Approved',
-              'Programming Language :: C',
-              'Programming Language :: Python',
-              'Topic :: Software Development',
-              'Topic :: Scientific/Engineering',
-              'Operating System :: Microsoft :: Windows',
-              'Operating System :: POSIX',
-              'Operating System :: Unix',
-              'Operating System :: MacOS',
-              'Programming Language :: Python :: 3.7',
-          ],
-          packages=find_packages(),
-          ext_modules = cythonize(extensions)
-          )


### PR DESCRIPTION
I was getting really frustrated with install so I added pyproject.toml and now the library will work with newer version of python 

```bash
git clone https://github.com/clewis7/ssm
pip install -e . 
```

I was using python3.11 before and that was working with install but I need fpl with imgui for some viz stuff so I need >=3.12